### PR TITLE
fix PHP notice in Breadcrumbbuilder if field_channel is not available

### DIFF
--- a/modules/thunder_article/src/Breadcrumb/ThunderArticleBreadcrumbBuilder.php
+++ b/modules/thunder_article/src/Breadcrumb/ThunderArticleBreadcrumbBuilder.php
@@ -140,7 +140,7 @@ class ThunderArticleBreadcrumbBuilder implements BreadcrumbBuilderInterface {
 
     // Add all parent forums to breadcrumbs.
     /** @var \Drupal\Taxonomy\TermInterface $term */
-    $term = $node->field_channel->entity;
+    $term = !(empty($node->field_channel)) ? $node->field_channel->entity : '';
 
     if ($term) {
       $breadcrumb->addCacheableDependency($term);


### PR DESCRIPTION
While using thunder on a project w/o having the **Channel** vocabulary and the Fiedl **field_channel** on the content type article we got an PHP notice. This should be fixed by this PR. In here we just check for the existence of the field_channel.