### PR TITLE
DKRFTN-695: fix php fatal while not having an node object in ThunderArticleBreadcrumbBuilder applies method

### DIFF
--- a/modules/thunder_article/src/Breadcrumb/ThunderArticleBreadcrumbBuilder.php
+++ b/modules/thunder_article/src/Breadcrumb/ThunderArticleBreadcrumbBuilder.php
@@ -120,7 +120,7 @@ class ThunderArticleBreadcrumbBuilder implements BreadcrumbBuilderInterface {
   public function applies(RouteMatchInterface $route_match) {
     // This breadcrumb apply only for all articles
     $parameters = $route_match->getParameters()->all();
-    if (isset($parameters['node'])) {
+    if (isset($parameters['node']) && is_object($parameters['node'])) {
       return $parameters['node']->getType() == 'article';
     }
     return FALSE;


### PR DESCRIPTION
While using the **Revert Revision** function of the drupal core revisioning system, we get an fatal error coming from the ThunderArticleBreadcrumbBuilder applies method. In this case we don't have a node object. The PR fixes this behaviour by explicitly checking for an object. 