### PR TITLE
translate 'Medien' into english

### DIFF
--- a/modules/thunder_paragraphs/config/install/field.field.paragraph.instagram.field_media.yml
+++ b/modules/thunder_paragraphs/config/install/field.field.paragraph.instagram.field_media.yml
@@ -9,7 +9,7 @@ id: paragraph.instagram.field_media
 field_name: field_media
 entity_type: paragraph
 bundle: instagram
-label: Medien
+label: Media
 description: ''
 required: true
 translatable: true

--- a/modules/thunder_paragraphs/config/install/field.field.paragraph.twitter.field_media.yml
+++ b/modules/thunder_paragraphs/config/install/field.field.paragraph.twitter.field_media.yml
@@ -9,7 +9,7 @@ id: paragraph.twitter.field_media
 field_name: field_media
 entity_type: paragraph
 bundle: twitter
-label: Medien
+label: Media
 description: ''
 required: true
 translatable: true


### PR DESCRIPTION
Twitter and instagram paragraphs had a german label.