### PR TITLE
check if view exists before using it

### DIFF
--- a/modules/thunder_media/thunder_media.module
+++ b/modules/thunder_media/thunder_media.module
@@ -58,12 +58,18 @@ function thunder_media_page_attachments(array &$page) {
  * Implements hook_menu_local_actions_alter().
  */
 function thunder_media_menu_local_actions_alter(&$local_actions) {
-  $local_actions['media.add']['appears_on'][] = 'view.thunder_media.media_page_list';
+  $view = \Drupal::entityTypeManager()->getStorage('view')->load('thunder_media');
+  if ($view) {
+    $local_actions['media.add']['appears_on'][] = 'view.thunder_media.media_page_list';
+  }
 }
 
 /**
  * Implements hook_menu_links_discovered_alter().
  */
 function thunder_media_menu_links_discovered_alter(&$links) {
-  $links['entity.media.collection']['route_name'] = 'view.thunder_media.media_page_list';
+  $view = \Drupal::entityTypeManager()->getStorage('view')->load('thunder_media');
+  if ($view) {
+    $links['entity.media.collection']['route_name'] = 'view.thunder_media.media_page_list';
+  }
 }


### PR DESCRIPTION
When updating from a previous release to the current dev head, an error is occuring because of a missing view. This adds a tests if the view exists, before using it