### PR TITLE
Issue #2915666: prevent duplicate content after split

### DIFF
--- a/modules/thunder_paragraphs/modules/paragraph_split_text/js/plugins/splittext/plugin.js
+++ b/modules/thunder_paragraphs/modules/paragraph_split_text/js/plugins/splittext/plugin.js
@@ -144,7 +144,8 @@
           }
           // Editor id is changed after submit
           $(document).ajaxComplete(function (e, xhr, settings) {
-            if (settings.extraData._triggering_element_name === triggeringElementName) {
+            var eventElement = settings.extraData._triggering_element_name;
+            if (eventElement === triggeringElementName) {
               // Paragraph is added above original
               // Get new paragraph delta
               var newDelta = $('.paragraph-item').length - 1;
@@ -159,8 +160,22 @@
               var newEditorId = newEditor.attr('id');
 
               // Set content to editors
-              CKEDITOR.instances[newEditorId].setData(oldContent);
-              CKEDITOR.instances[originalEditorId].setData(newContent.getHtml());
+              if (newEditorId !== undefined) {
+                CKEDITOR.instances[newEditorId].setData(oldContent, {
+                  callback: function () {
+                    this.updateElement();
+                    this.element.data('editor-value-is-changed', true);
+                  }
+                });
+              }
+              if (originalEditorId !== undefined) {
+                CKEDITOR.instances[originalEditorId].setData(newContent.getHtml(), {
+                  callback: function () {
+                    this.updateElement();
+                    this.element.data('editor-value-is-changed', true);
+                  }
+                });
+              }
             }
           });
         }


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request - thank you!

- [x] All coding styles are fulfilled. ([How to check for cs issues?](https://github.com/BurdaMagazinOrg/thunder-dev-tools/blob/master/README.md#code-style-guidelines))
- [x] All tests are running locally. ([How to run the test?](https://github.com/BurdaMagazinOrg/thunder-distribution/blob/develop/docs/development.md#how-to-run-the-tests))
- [-] Necessary update hooks are provided.
- [-] User roles have correct access for new introduced permission.
- [-] Every thunder module has a README.md in its root. Follow [this guidelines](https://www.drupal.org/node/2181737), but we don't need every topic.
- [-] Code is covered with well-balanced amount of inline comments.

After split paragraphs, content was duplicated.
This PR avoids that error by distinguishing `newEditorId`/`originalEditorId` and marking `editor-value-is-changed` to updated editor.
