### PR TITLE
Issue #2930941 by alexpott: Make travis scripts a little bit more robust

### DIFF
--- a/scripts/travis/01-setup-environment.sh
+++ b/scripts/travis/01-setup-environment.sh
@@ -28,7 +28,7 @@ export PHP_IMAGICK_VERSION
 # Get latest version of Yaml PHP library (for PHP 5.6 -> Yaml version 1.x will be used)
 if [[ $TRAVIS_PHP_VERSION = '5.6' ]] ; then
   PHP_YAML_VERSION=`curl -L -s -H 'Accept: application/json' https://api.github.com/repos/php/pecl-file_formats-yaml/tags | jq -r '[ .[].name | select(index("1.")==0) ] | .[0]'`
-elif [[ $TRAVIS_PHP_VERSION = '7.1' ]] ; then
+else
   PHP_YAML_VERSION=`curl -L -s -H 'Accept: application/json' https://api.github.com/repos/php/pecl-file_formats-yaml/tags | jq -r '.[0].name'`
 fi;
 export PHP_YAML_VERSION

--- a/scripts/travis/01-setup-environment.sh
+++ b/scripts/travis/01-setup-environment.sh
@@ -33,6 +33,11 @@ else
 fi;
 export PHP_YAML_VERSION
 
+# Set a default install method if none set.
+if [[ ${INSTALL_METHOD} == "" ]]; then
+  export INSTALL_METHOD=composer
+fi;
+
 # Manual overrides of environment variables by commit messages. To override a variable add something like this to
 # your commit message:
 # git commit -m="Your commit message [TEST_UPDATE=true]"


### PR DESCRIPTION
The travis scripts are unnecessarily specific when setting the environment variable PHP_YAML_VERSION. If this is not set then later scripts fail. Let's just assume PHP 7 and special case PHP 5.6.

Also, there are dependencies on the environmental variable INSTALL_METHOD - let's set a default.

Make sure these boxes are checked before submitting your pull request - thank you!

- [x] All coding styles are fulfilled. ([How to check for cs issues?](https://github.com/BurdaMagazinOrg/thunder-dev-tools/blob/master/README.md#code-style-guidelines))
- [x] All tests are running locally. ([How to run the test?](https://github.com/BurdaMagazinOrg/thunder-distribution/blob/develop/docs/development.md#how-to-run-the-tests))
- [x] Necessary update hooks are provided.
- [x] User roles have correct access for new introduced permission.
- [x] Every thunder module has a README.md in its root. Follow [this guidelines](https://www.drupal.org/node/2181737), but we don't need every topic.
- [x] Code is covered with well-balanced amount of inline comments.

If you are really awesome, then your feature is covered by additional tests. Well done!
