### PR TITLE
Issue #2931742: Show one split button instead of two

### DIFF
--- a/config/install/editor.editor.basic_html.yml
+++ b/config/install/editor.editor.basic_html.yml
@@ -39,7 +39,6 @@ settings:
           name: Tools
           items:
             - Source
-            - SplitTextAfter
             - SplitTextBefore
   plugins:
     stylescombo:

--- a/tests/src/FunctionalJavascript/Integration/ParagraphSplitTest.php
+++ b/tests/src/FunctionalJavascript/Integration/ParagraphSplitTest.php
@@ -34,32 +34,6 @@ class ParagraphSplitTest extends ThunderJavascriptTestBase {
   protected static $selectorTemplate = "textarea[name='%s[%d][subform][field_text][0][value]']";
 
   /**
-   * Test split of paragraph after a selection.
-   */
-  public function testParagraphSplitAfter() {
-    $firstParagraphContent = '<p>Content that will be in the first paragraph after the split.</p>';
-    $secondParagraphContent = '<p>Content that will be in the second paragraph after the split.</p>';
-
-    $this->articleFillNew([]);
-
-    // Add text paragraph with two elements.
-    $this->addTextParagraph(static::$paragraphsField, $firstParagraphContent . $secondParagraphContent);
-
-    // Select first element in editor.
-    $this->selectCkEditorElement($this->getCkEditorCssSelector(0), 0);
-
-    // Split text paragraph after the current selection.
-    $this->clickParagraphSplitButton('after');
-    $this->assertSession()->assertWaitOnAjaxRequest();
-
-    // Test if all texts are in the correct paragraph.
-    // When splitting after the current position, the new paragraph will
-    // be in front of the old, that is why the paragraph delta is reversed.
-    $this->assertCkEditorContent($this->getCkEditorCssSelector(1), $firstParagraphContent . PHP_EOL);
-    $this->assertCkEditorContent($this->getCkEditorCssSelector(0), $secondParagraphContent . PHP_EOL);
-  }
-
-  /**
    * Test split of paragraph before a selection.
    */
   public function testParagraphSplitBefore() {


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request - thank you!

- [ ] All coding styles are fulfilled. ([How to check for cs issues?](https://github.com/BurdaMagazinOrg/thunder-dev-tools/blob/master/README.md#code-style-guidelines))
- [ ] All tests are running locally. ([How to run the test?](https://github.com/BurdaMagazinOrg/thunder-distribution/blob/develop/docs/development.md#how-to-run-the-tests))
- [ ] Necessary update hooks are provided.
- [ ] User roles have correct access for new introduced permission.
- [ ] Every thunder module has a README.md in its root. Follow [this guidelines](https://www.drupal.org/node/2181737), but we don't need every topic.
- [ ] Code is covered with well-balanced amount of inline comments.

If you are really awesome, then your feature is covered by additional tests. Well done!
