### PR TITLE
Issue #2937285: run updates of enabled modules only.

### DIFF
--- a/modules/thunder_updater/thunder_updater.services.yml
+++ b/modules/thunder_updater/thunder_updater.services.yml
@@ -14,4 +14,4 @@ services:
     arguments: ['@config_update.config_list', '@config_update.config_update', '@thunder_updater.config_differ', '@thunder_updater.config_diff_transformer', '@module_handler', '@serialization.yaml']
   thunder_updater:
     class: Drupal\thunder_updater\Updater
-    arguments: ['@user.shared_tempstore', '@config.factory', '@module_installer', '@config_update.config_update', '@thunder_updater.config_handler', '@thunder_updater.logger', '@thunder_updater.update_checklist']
+    arguments: ['@user.shared_tempstore', '@config.factory', '@module_handler', '@module_installer', '@config_update.config_update', '@thunder_updater.config_handler', '@thunder_updater.logger', '@thunder_updater.update_checklist']


### PR DESCRIPTION
When running `thunder_update_8112()` some other update functions are called. Unfortunately the updater does not check if the module of the requested function is enabled. If (i.e.) you don't have _thunder_article_ enabled, the update will fail.

tldr; Fixes https://www.drupal.org/project/thunder/issues/2937285.
