### PR TITLE
Issue #3003428 by Insasse, indigoxela, chr.fritsch: Disabled content_moderation breaks Thunder

### DIFF
--- a/modules/thunder_article/src/Form/ThunderNodeForm.php
+++ b/modules/thunder_article/src/Form/ThunderNodeForm.php
@@ -69,7 +69,7 @@ class ThunderNodeForm extends NodeForm {
     /** @var \Drupal\node\NodeInterface $entity */
     $entity = $form_object->getEntity();
 
-    if ($this->moderationInfo->hasPendingRevision($entity)) {
+    if ($this->moderationInfo && $this->moderationInfo->hasPendingRevision($entity)) {
       $this->messenger()->addWarning($this->t('This %entity_type has unpublished changes from user %user.', ['%entity_type' => $entity->get('type')->entity->label(), '%user' => $entity->getRevisionUser()->label()]));
     }
 

--- a/thunder.profile
+++ b/thunder.profile
@@ -226,9 +226,11 @@ function thunder_themes_installed($theme_list) {
 function thunder_modules_installed($modules) {
 
   if (in_array('content_moderation', $modules)) {
-    /** @var Drupal\config_update\ConfigRevertInterface $configReverter */
-    $configReverter = \Drupal::service('config_update.config_update');
-    $configReverter->import('user_role', 'restricted_editor');
+    if (!Role::load('restricted_editor')) {
+      /** @var Drupal\config_update\ConfigRevertInterface $configReverter */
+      $configReverter = \Drupal::service('config_update.config_update');
+      $configReverter->import('user_role', 'restricted_editor');
+    }
 
     // Granting permissions only for "editor" and "seo" user roles.
     $roles = Role::loadMultiple(['editor', 'seo']);
@@ -378,5 +380,14 @@ function thunder_entity_base_field_info_alter(&$fields, EntityTypeInterface $ent
       'weight' => 100,
       'settings' => [],
     ]);
+  }
+}
+
+/**
+ * Implements hook_field_widget_info_alter().
+ */
+function thunder_field_widget_info_alter(array &$info) {
+  if (!\Drupal::moduleHandler()->moduleExists('content_moderation')) {
+    unset($info['thunder_moderation_state_default']);
   }
 }


### PR DESCRIPTION
…moderation breaks Thunder

Make sure these boxes are checked before submitting your pull request - thank you!

- [ ] All coding styles are fulfilled. ([How to check for cs issues?](https://github.com/BurdaMagazinOrg/thunder-dev-tools/blob/master/README.md#code-style-guidelines))
- [ ] All tests are running locally. ([How to run the test?](https://github.com/BurdaMagazinOrg/thunder-distribution/blob/develop/docs/development.md#how-to-run-the-tests))
- [ ] Necessary update hooks are provided.
- [ ] User roles have correct access for new introduced permission.
- [ ] Every thunder module has a README.md in its root. Follow [this guidelines](https://www.drupal.org/node/2181737), but we don't need every topic.
- [ ] Code is covered with well-balanced amount of inline comments.

If you are really awesome, then your feature is covered by additional tests. Well done!
