### PR TITLE
Fixed support of update helper checklistapi deprecation

### DIFF
--- a/modules/thunder_updater/thunder_updater.install
+++ b/modules/thunder_updater/thunder_updater.install
@@ -87,21 +87,45 @@ function thunder_updater_update_8001() {
     }
 
     // Migrate Checklist API configuration.
-    $thunder_updater_checklist = $config_factory->getEditable('checklistapi.progress.thunder_updater');
-    $update_helper_checklist = $config_factory->getEditable('checklistapi.progress.update_helper_checklist');
+    $update_helper_checklist_definition = checklistapi_get_checklist_info('update_helper_checklist');
+    if ($update_helper_checklist_definition && isset($update_helper_checklist_definition['#storage']) && $update_helper_checklist_definition['#storage'] == 'state') {
+      /** @var \Drupal\checklistapi\Storage\ConfigStorage $old_config_storage */
+      $old_config_storage = \Drupal::service('checklistapi_storage.config');
+      $thunder_updater_progress = $old_config_storage->setChecklistId('thunder_updater')
+        ->getSavedProgress();
 
-    $items = $thunder_updater_checklist->get('progress.#items');
-    if (is_array($items)) {
-      foreach ($items as $update_id => $update_info) {
-        $update_helper_checklist->set('progress.#items.thunder:' . $update_id, $update_info);
+      /** @var \Drupal\checklistapi\Storage\StateStorage $new_state_storage */
+      $new_state_storage = \Drupal::service('checklistapi_storage.state');
+      $update_helper_progress = $new_state_storage->setChecklistId('update_helper_checklist')
+        ->getSavedProgress();
+
+      if (!empty($thunder_updater_progress) && is_array($thunder_updater_progress['#items'])) {
+        foreach ($thunder_updater_progress['#items'] as $update_id => $update_info) {
+          $update_helper_progress['#items']['thunder:' . $update_id] = $update_info;
+        }
       }
+
+      $update_helper_progress['#completed_items'] = count($update_helper_progress['#items']);
+      $new_state_storage->setChecklistId('update_helper_checklist')
+        ->setSavedProgress($update_helper_progress);
+    }
+    else {
+      $thunder_updater_checklist = $config_factory->getEditable('checklistapi.progress.thunder_updater');
+      $update_helper_checklist = $config_factory->getEditable('checklistapi.progress.update_helper_checklist');
+
+      $items = $thunder_updater_checklist->get('progress.#items');
+      if (is_array($items)) {
+        foreach ($items as $update_id => $update_info) {
+          $update_helper_checklist->set('progress.#items.thunder:' . $update_id, $update_info);
+        }
+      }
+
+      $update_helper_checklist->set('progress.#completed_items', $update_helper_checklist->get('progress.#completed_items') + $thunder_updater_checklist->get('progress.#completed_items'));
+      $update_helper_checklist->save();
     }
 
-    $update_helper_checklist->set('progress.#completed_items', $update_helper_checklist->get('progress.#completed_items') + $thunder_updater_checklist->get('progress.#completed_items'));
-    $update_helper_checklist->save();
-
     // Remove Thunder Updater checklist configuration.
-    $thunder_updater_checklist->delete();
+    $config_factory->getEditable('checklistapi.progress.thunder_updater')->delete();
   }
 
   // We want to remove all migrated updates, so that uninstall can work.


### PR DESCRIPTION
This is support for update_helper deprecation fix for `checklistapi` integration submodule.

PR for update helper can be found here: https://github.com/BurdaMagazinOrg/module-update_helper/pull/10

The main reason for changes in distribution is that storage for progress has been changed in update helper and we have to migrate data accordingly.